### PR TITLE
Update ExplicitWaitClass.java

### DIFF
--- a/FirstSeleniumProject/src/com/selenium/wait/ExplicitWaitClass.java
+++ b/FirstSeleniumProject/src/com/selenium/wait/ExplicitWaitClass.java
@@ -9,20 +9,20 @@ import org.openqa.selenium.WebElement;
 import org.openqa.selenium.chrome.ChromeDriver;
 import org.openqa.selenium.support.ui.ExpectedConditions;
 import org.openqa.selenium.support.ui.WebDriverWait;
-import org.testng.annotations.AfterMethod;
-import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.AfterTest;
+import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
 
 public class ExplicitWaitClass {
 
 	WebDriver driver = null;
 
-	@BeforeMethod
+	@BeforeTest
 	public void setUp() {
-
+		driver = new ChromeDriver();
 		System.setProperty("webdriver.chrome.driver",
 				"/Users/anshul/JavaTraining/FirstSeleniumProject/drivers/chromedriver");
-		driver = new ChromeDriver();
+		
 		driver.manage().window().maximize();
 
 		driver.get("file:///Users/anshul/Downloads/ExplicitWait.html");
@@ -33,7 +33,7 @@ public class ExplicitWaitClass {
 		// driver.get("file:///C:/Selenium/abcd.html");
 	}
 
-	@AfterMethod
+	@AfterTest
 	public void closeBrowser() {
 		driver.quit();
 	}


### PR DESCRIPTION
Changed @BeforeMethod to @BeforeTest and @AfterMethod to @AfterTest annotations in the Selenium TestNG test suite to ensure proper setup and teardown of the WebDriver instance.

The reason behind this change is due to TestNG annotations behavior. In TestNG, @BeforeMethod and @AfterMethod are executed before and after each @Test method, respectively. As a result, the WebDriver instance was not being shared between the test methods as expected, leading to a 'null' reference error when trying to close the browser in the @AfterMethod.

By using @BeforeTest and @AfterTest annotations, the WebDriver setup is now performed before the entire test suite starts (@BeforeTest) and the teardown is done after all the tests have run (@AfterTest). This ensures the WebDriver instance is initialized once at the beginning of the test suite and closed after all the tests have completed, preventing the 'null' reference issue and ensuring a smoother execution of the test suite.

This adjustment ensures a more reliable and consistent handling of the WebDriver instance throughout the entire test suite, enhancing the stability and reliability of the test automation setup.