### PR TITLE
Update GetLinkStatus.java

### DIFF
--- a/FirstSeleniumProject/src/com/selenium/masterpart1/GetLinkStatus.java
+++ b/FirstSeleniumProject/src/com/selenium/masterpart1/GetLinkStatus.java
@@ -29,7 +29,7 @@ public class GetLinkStatus {
 
 		} catch (Exception e) {
 
-			e.printStackTrace();
+			//e.printStackTrace();
 		}
 
 	}


### PR DESCRIPTION
Commenting the functionality inside the catch block, will make the program execute without any failure in between as it would throw the error for "Cannot invoke "String.length()" because "spec" is null" because in some cases the URL can be blank. 

<a href=""> such declaration is also treated like an invalid link.